### PR TITLE
Fixing a broken unit test.

### DIFF
--- a/docker_wrapper_test.go
+++ b/docker_wrapper_test.go
@@ -154,7 +154,7 @@ func TestParseJsonFromString_label(t *testing.T) {
 	assert.Equal(t, "/var/log/sample-access.log", accesslog_hash["File"], "Expected correct File")
 
 	errorlog_hash := test_list[1].(map[string]interface{})
-	assert.Equal(t, "example_error_log", errorlog_hash["Topic"], "Expected correct Topic")
+	assert.Equal(t, "sample_error_log", errorlog_hash["Topic"], "Expected correct Topic")
 	assert.Equal(t, "/var/log/sample-error.log", errorlog_hash["File"], "Expected correct File")
 }
 


### PR DESCRIPTION
This test isn't passing properly. Looking at the git log,
it seems like it was a typo/mistake when open-sourcing
this project which has gone undiscovered until now.

This is a 1-word change, typing down this long a commit
message feels truly overkill.
